### PR TITLE
Improve build and release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,10 +114,8 @@ jobs:
           name: create release
           command: npm run release:create
       - run:
-          name: delete release tag
-          command: git push --delete origin $CIRCLE_TAG
-      - run: |
-          hub release delete $CIRCLE_TAG
+          name: clean up release
+          command: hub release delete $CIRCLE_TAG
 
   deploy:
     <<: *defaults

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 coverage
-/lib
+/dist
 .idea

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Open Source Code of Conduct
+This code of conduct outlines our expectations for participants within the Identity.com Open Source community, as well as steps to reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all and expect our code of conduct to be honored. Anyone who violates this code of conduct may be banned from the community.
+
+
+# Our open source community strives to:
+
+
+* Be friendly and patient.
+* Be welcoming: We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+* Be considerate: Your work will be used by other people, and you in turn will depend on the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we’re a world-wide community, so you might not be communicating in someone else’s primary language.
+* Be respectful: Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one.
+* Be careful in the words that you choose: we are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren’t acceptable. This includes, but is not limited to:
+   * Violent threats or language directed against another person.
+   * Discriminatory jokes and language.
+   * Posting sexually explicit or violent material.
+   * Posting (or threatening to post) other people’s personally identifying information (“doxing”).
+   * Personal insults, especially those using racist or sexist terms.
+   * Unwelcome sexual attention.
+   * Advocating for, or encouraging, any of the above behavior.
+   * Repeated harassment of others. In general, if someone asks you to stop, then stop.
+   * When we disagree, try to understand why: Disagreements, both social and technical, happen all the time. It is important that we resolve disagreements and differing views constructively.
+   * Remember that we’re different. The strength of our community comes from its diversity, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+
+
+This code is not exhaustive or complete. It serves to distill our common understanding of a collaborative, shared environment, and goals. We expect it to be followed in spirit as much as in the letter.
+
+
+# Diversity Statement
+We encourage everyone to participate and are committed to building a community for all. Although we may not be able to satisfy everyone, we all agree that everyone is equal. Whenever a participant has made a mistake, we expect them to take responsibility for it. If someone has been harmed or offended, it is our responsibility to listen carefully and respectfully, and do our best to right the wrong.
+
+
+Although this list cannot be exhaustive, we explicitly honor diversity in age, gender, gender identity or expression, culture, ethnicity, language, national origin, political beliefs, profession, race, religion, sexual orientation, socioeconomic status, and technical ability. We will not tolerate discrimination based on any of the protected characteristics above, including participants with disabilities.
+
+
+# Reporting Issues
+If you experience or witness unacceptable behavior—or have any other concerns—please report it by contacting us via https://www.identity.com/about/contact-us/. All reports will be handled with discretion. In your report please include:
+
+* Your contact information.
+* Names (real, nicknames, or pseudonyms) of any individuals involved. If there are additional witnesses, please include them as well. Your account of what occurred, and if you believe the incident is ongoing. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger), please include a link.
+* Any additional information that may be helpful.
+
+
+After filing a report, a representative will contact you personally. If the person who is harassing you is part of the response team, they will recuse themselves from handling your incident. A representative will then review the incident, follow up with any additional questions, and make a decision as to how to respond. We will respect confidentiality requests for the purpose of protecting victims of abuse.
+
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately. If an individual engages in unacceptable behavior, the representative may take any action they deem appropriate, up to and including a permanent ban from our community without warning.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# How to Contribute
+We’re still working out the kinks to make contributing to this project as easy and transparent as possible, but we’re not quite there yet. Hopefully this document makes the process for contributing clear and answers some questions that you may have.
+
+# Code of Conduct
+Identity.com has adopted a [Code of Conduct](CODE_OF_CONDUCT.md) that we expect project participants to adhere to. Please read the full text so that you can understand what actions will and will not be tolerated.
+
+# Contributors & Team Members Development
+Most internal changes made by Civic & Identity.com engineers will be synced to GitHub. Civic & Identity.com use this code in production. The team is likely to have an enterprise version of the code containing specific environment details and that part is not synced with the code here. 
+Changes from the community are handled through GitHub pull requests which go through our review process. Once a change made on GitHub is approved, it will be imported to the Civic & Identity.com internal repositories.
+
+# Branch Organization
+We will do our best to keep the master branch in good shape, with tests passing at all times. But in order to move fast, we will make API changes that your application might not be compatible with. We recommend that you use the latest stable and published version.
+If you send a pull request, please do it against the master branch. We maintain stable branches for major versions separately.We accept pull requests against latest major branch directly if it is a bugfix related to its version. This fix will be also applied to the master branch by the Core team.
+
+# Semantic Versioning
+This software follows semantic versioning. We release patch versions for bug fixes, minor versions for new features, and major versions for any breaking changes. When we make breaking changes, we also introduce deprecation warnings in a minor version so that our users learn about the upcoming changes and migrate their code in advance.
+Every significant change is documented in the changelog file.
+
+# Bugs
+## Where to Find Known Issues
+We are using GitHub Issues for our public bugs. Core team will keep a close eye on this and try to make it clear when we have an internal fix in progress. Before filing a new task, try to make sure your problem doesn’t already exist.
+## Reporting New Issues
+The best way to get your bug fixed is to provide a reduced test case.
+How to Get in Touch
+
+GitHub Issues: Create a ticket with the specific tag: [question] ; [feature request]; [suggestion] ; [discussion]
+Identity.com website contact form
+
+# Proposing a Change
+If you intend to change the public API, or make any non-trivial changes to the implementation, we recommend filing an issue. This lets us reach an agreement on your proposal before you put significant effort into it.
+If you’re only fixing a bug, it’s fine to submit a pull request right away but we still recommend to file an issue detailing what you’re fixing. This is helpful in case we don’t accept that specific fix but want to keep track of the issue.
+
+# Your First Pull Request
+Working on your first Pull Request? You can learn how from this free video series:
+[How to Contribute](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github) to an Open Source Project on GitHub
+If you decide to fix an issue, please be sure to check the comment thread in case somebody is already working on a fix. If nobody is working on it at the moment, please leave a comment stating that you intend to work on it so other people don’t accidentally duplicate your effort.
+If somebody claims an issue but doesn’t follow up for more than two weeks, it’s fine to take it over but you should still leave a comment.
+
+# Sending a Pull Request
+The Identity.com team is monitoring for pull requests. We will review your pull request and either merge it, request changes to it, or close it with an explanation.
+Before submitting a pull request, please make sure the following is done:
+Fork the repository and create your branch from master.
+Run `npm install` in the repository root.
+If you’ve fixed a bug or added code that should be tested, add tests!
+Ensure the test suite passes (`npm test`). 
+Format your code with eslint (`npm run lint`).
+If you haven’t already, complete the CLA.
+
+# Contributor License Agreement (CLA)
+By contributing to Identity.com projects, you agree that your contributions will be licensed under its MIT license.
+Contribution Prerequisites
+
+# Prerequisites
+Please follow [README](README.md) instructions.
+
+# Development Workflow
+Please follow [README](README.md) instructions.
+
+# Style Guide
+We use an automatic code formatter called ESLint. Run `npm run lint` after making any changes to the code.
+Then, our linter will catch most issues that may exist in your code.
+However, there are still some styles that the linter cannot pick up. If you are unsure about something, looking at Airbnb’s Style Guide will guide you in the right direction.
+
+# License
+By contributing to Identity.com projects, you agree that your contributions will be licensed under its MIT license.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "verifiable-presentations",
-  "version": "0.0.1",
+  "name": "@identity.com/verifiable-presentations",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "@identity.com/verifiable-presentations",
   "version": "0.0.1",
   "description": "Utility Library to securely handle verifiable presentations",
-  "main": "lib/index.ts",
-  "types": "lib/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
-    "lib/**/*"
+    "dist/**/*"
   ],
   "scripts": {
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/verifiable-presentations",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Utility Library to securely handle verifiable presentations",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es5",
     "module": "commonjs",
     "declaration": true,
-    "outDir": "./lib",
+    "outDir": "./dist",
     "strict": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Improve build and release:
- Fix tag deletion in build/release
- Add code of conduct and contributing guides
- Rename lib folder to dist (this is how it is named in the other identity repositories)
- bump version to 0.0.2