### PR TITLE
Retrieve a map of multiple claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Verifiable-presentations provides methods to run operations over a collection of
 Usage example:
 
 ```
-import { secureRedundantManager } from '../index';
+import { secureRedundantManager } from '@identity.com/verifiable-presentations';
 
 const artifacts = {
     presentations: [


### PR DESCRIPTION
Implement method `mapClaimValues` to retrieve multiple claim values mapped to identifiers.

Usage example:
```
// mapping from identifier to a SearchClaimCriteria
const mapping = {
    contact : {
        claimPath: 'contact.phoneNumber.number',
        credentialRef: {
            identifier: phoneNumberCredential.identifier,
            uid: phoneNumberCredential.id
        },
    },
    docNumber : {
        claimPath: 'document.number',
    },
    name: {
        identifier: 'claim-cvc:Name.givenNames-v1',
    }
};

const mappedClaimValues = await presentationManager.mapClaimValues(mapping);        
```

The `mappedClaimValues` returned in the example will be as below:
```
{
    contact: '31988889999',
    docNumber: '9999999999',
    name: 'Civic'
}
```

The _mapClaimValues_ method also supports an optional parameter - _flatten_ - that will make it return flat objects as below:
```
[
    {
         name: 'contact',
         value: '31988889999'
     },
     {
          name: 'docNumber',
          value: '9999999999'
     },
     {
          name: 'name',
          value: 'Civic'
     }
]
```  